### PR TITLE
Adding in Xcode 6.x's UUID.

### DIFF
--- a/Distcc 3.2/Distcc 3.2-Info.plist
+++ b/Distcc 3.2/Distcc 3.2-Info.plist
@@ -4,6 +4,7 @@
 <dict>
 	<key>DVTPlugInCompatibilityUUIDs</key>
 	<array>
+		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
 	</array>
 	<key>BuildMachineOSBuild</key>


### PR DESCRIPTION
Here's a quick change to include Xcode 6's UUID in the DVTPlugInCompatibilityUUIDs list.
